### PR TITLE
Fix GitHub pages automation

### DIFF
--- a/.github/workflows/gh_pages.yml
+++ b/.github/workflows/gh_pages.yml
@@ -11,11 +11,22 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+        with:
+          ref: main
+          path: main
+      - uses: actions/checkout@v2
+        with:
+          ref: gh-pages
+          path: gh-pages
       - name: generate-json
         run: |
-          python gen_skill_list.py
+          python main/gen_skill_list.py
+      - name: copy updated json
+        run: |
+          cp main/skills.json gh-pages/skills.json
       - uses: EndBug/add-and-commit@v7
         with:
-          add: skills.json
+          cwd: ./gh-pages
           branch: gh-pages
+          add: skills.json
           message: "Automated Metadata Update"

--- a/gen_skill_list.py
+++ b/gen_skill_list.py
@@ -12,7 +12,7 @@ output = {
 }
 dir_to_check = dirname(__file__) or join(getcwd(), "main")
 for skill in [f for f in listdir(dir_to_check) if f.endswith(".json")]:
-    with open(skill) as f:
+    with open(join(dir_to_check, skill)) as f:
         output["items"].append(json.load(f))
 
 with open("skills.json", "w") as f:

--- a/gen_skill_list.py
+++ b/gen_skill_list.py
@@ -15,5 +15,5 @@ for skill in [f for f in listdir(dir_to_check) if f.endswith(".json")]:
     with open(join(dir_to_check, skill)) as f:
         output["items"].append(json.load(f))
 
-with open("skills.json", "w") as f:
+with open(join(dir_to_check, "skills.json"), "w") as f:
     json.dump(output, f, indent=4)

--- a/gen_skill_list.py
+++ b/gen_skill_list.py
@@ -1,5 +1,5 @@
 from os import listdir, getcwd
-from os.path import dirname
+from os.path import dirname, join
 import json
 
 output = {
@@ -10,7 +10,7 @@ output = {
     "feed_url": "https://openvoiceos.github.io/OVOS-skills-store/skills.json",
     "items": []
 }
-dir_to_check = dirname(__file__) or getcwd()
+dir_to_check = dirname(__file__) or join(getcwd(), "main")
 for skill in [f for f in listdir(dir_to_check) if f.endswith(".json")]:
     with open(skill) as f:
         output["items"].append(json.load(f))


### PR DESCRIPTION
Fixes Automation added in #13.

Can be tested in any fork of OVOS-skills-store by merging into `main` and then modifying any skill.json in `main`. When changes are committed/merged, automation should update skills.json in the gh-pages branch automatically.