### PR TITLE
Add ovos-skill-fairytales

### DIFF
--- a/raw_jsons/ovos-skill-fairytales-andlo.json
+++ b/raw_jsons/ovos-skill-fairytales-andlo.json
@@ -26,5 +26,6 @@
     "media": [],
     "gui": []
   },
-  "author": "andlo"
+  "author": "andlo",
+  "icon": "https://raw.githubusercontent.com/andlo/ovos-skill-fairytales/master/story-512.png"
 }

--- a/raw_jsons/ovos-skill-fairytales-andlo.json
+++ b/raw_jsons/ovos-skill-fairytales-andlo.json
@@ -1,0 +1,30 @@
+{
+  "skill_id": "ovos-skill-fairytales.andlo",
+  "source": "https://github.com/andlo/ovos-skill-fairytales",
+  "package_name": "ovos-skill-fairytales",
+  "name": "Fairy Tales",
+  "description": "Tells fairy tales by Hans Christian Andersen and the Brothers Grimm, in English, Danish, German, Spanish, French, Italian, Dutch and Portuguese (Grimm only in Portuguese).",
+  "examples": [
+    "tell me a story about Cinderella",
+    "read me a fairy tale",
+    "continue the story"
+  ],
+  "tags": [
+    "entertainment",
+    "stories",
+    "fairytales",
+    "andersen",
+    "grimm"
+  ],
+  "images": [],
+  "license": "gpl-3.0",
+  "extra_plugins": {
+    "core": [],
+    "PHAL": [],
+    "listener": [],
+    "audio": [],
+    "media": [],
+    "gui": []
+  },
+  "author": "andlo"
+}


### PR DESCRIPTION
Adds ovos-skill-fairytales (Hans Christian Andersen and Brothers Grimm fairy tales, 8 languages) to the store.

- Source: https://github.com/andlo/ovos-skill-fairytales
- PyPI: https://pypi.org/project/ovos-skill-fairytales/
- License: GPL-3.0-or-later (OSI-approved)
- Validated locally with scripts/apply_submission.py before submitting.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added metadata for the Fairytales skill, including its description, example voice commands, tags, licensing information, author, and plugin details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->